### PR TITLE
Fix compatibility with nvcc & programs working without CUDA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,10 @@ find_package(CUDAToolkit REQUIRED)
 
 # Third-party
 add_subdirectory(third-party/cuda-kernel-loader)
-add_subdirectory(third-party/json)
+if (NOT nlohmann_json_FOUND AND NOT NLOHMANN_JSON_FOUND)
+  # Check for compatibility with tiny-cuda-nn whether the JSON library was already found elsewhere.
+  add_subdirectory(third-party/json)
+endif()
 add_subdirectory(third-party/magic_enum)
 if(NOT TARGET spdlog::spdlog)
     add_subdirectory(third-party/spdlog)

--- a/src_cpp/include/qmlp/qmlp.h
+++ b/src_cpp/include/qmlp/qmlp.h
@@ -1,8 +1,14 @@
 #pragma once
 
 #include "common.h"
-#include <spdlog/spdlog.h>
 #include <ckl/kernel_loader.h>
+
+namespace spdlog {
+class logger;
+namespace level {
+enum level_enum : int;
+}
+}
 
 QUICKMLP_NAMESPACE_BEGIN
 

--- a/src_cpp/include/qmlp/qmlp.h
+++ b/src_cpp/include/qmlp/qmlp.h
@@ -2,13 +2,7 @@
 
 #include "common.h"
 #include <ckl/kernel_loader.h>
-
-namespace spdlog {
-class logger;
-namespace level {
-enum level_enum : int;
-}
-}
+#include <spdlog/fwd.h>
 
 QUICKMLP_NAMESPACE_BEGIN
 

--- a/src_cpp/src/encoding_hashgrid.cpp
+++ b/src_cpp/src/encoding_hashgrid.cpp
@@ -2,6 +2,7 @@
 
 #include <tinyformat.h>
 #include <magic_enum.hpp>
+#include <spdlog/spdlog.h>
 #include <qmlp/kernels/encoding_hashgrid_config.cuh>
 #include <qmlp/kernels/loops.cuh>
 #include <qmlp/qmlp.h>

--- a/src_cpp/src/fused_network.cpp
+++ b/src_cpp/src/fused_network.cpp
@@ -1,6 +1,7 @@
 #include <qmlp/fused_network.h>
 
 #include <tinyformat.h>
+#include <spdlog/spdlog.h>
 #include <qmlp/qmlp.h>
 #include <unordered_set>
 #include <cmath>
@@ -24,7 +25,11 @@ namespace
 static int fetchSharedMemory()
 {
     cudaDeviceProp props;
-    CKL_SAFE_CALL(cudaGetDeviceProperties(&props, 0));
+    auto retVal = cudaGetDeviceProperties(&props, 0);
+    if (retVal == cudaErrorInsufficientDriver) {
+        return 32;
+    }
+    CKL_SAFE_CALL(retVal);
     if (props.warpSize != FusedNetwork::WARP_SIZE)
     {
         throw configuration_error("The warp size has changed, it is no longer %d but %d. This invalidates all algorithms!",

--- a/src_cpp/src/qmlp.cpp
+++ b/src_cpp/src/qmlp.cpp
@@ -1,4 +1,5 @@
 #include <qmlp/qmlp.h>
+#include <spdlog/spdlog.h>
 
 #include "spdlog/sinks/stdout_color_sinks.h"
 


### PR DESCRIPTION
Moved spdlog include to source files. Added check for return value of CUDA call in fetchSharedMemory to avoid errors on startup of programs linking to this library when CUDA is not available. Added check whether nlohman_json was already added by another project (like tiny-cuda-nn).