### PR TITLE
Added function for early deletion of instance & new error code check

### DIFF
--- a/src_cpp/include/qmlp/qmlp.h
+++ b/src_cpp/include/qmlp/qmlp.h
@@ -14,6 +14,8 @@ typedef std::shared_ptr<spdlog::logger> logger_t;
 class QuickMLP : public NonAssignable
 {
 private:
+    static std::unique_ptr<QuickMLP> INSTANCE;
+
     const logger_t logger_;
     const ckl::KernelLoader_ptr kl_;
     bool enableCompileDebugMode_;
@@ -25,6 +27,11 @@ public:
      * Returns the global quick-mlp instance
      */
     static QuickMLP& Instance();
+
+    /**
+     * Deletes the global quick-mlp instance
+     */
+    static void DeleteInstance();
 
     /**
      * Tests if CUDA is available.

--- a/src_cpp/src/fused_network.cpp
+++ b/src_cpp/src/fused_network.cpp
@@ -26,7 +26,8 @@ static int fetchSharedMemory()
 {
     cudaDeviceProp props;
     auto retVal = cudaGetDeviceProperties(&props, 0);
-    if (retVal == cudaErrorInsufficientDriver) {
+    if (retVal == cudaErrorInsufficientDriver || retVal == cudaErrorNoDevice)
+    {
         return 32;
     }
     CKL_SAFE_CALL(retVal);

--- a/src_cpp/src/qmlp.cpp
+++ b/src_cpp/src/qmlp.cpp
@@ -22,10 +22,20 @@ QuickMLP::QuickMLP()
     kl_->setFileLoader(std::make_shared<ckl::FilesystemLoader>(parent));
 }
 
+std::unique_ptr<QuickMLP> QuickMLP::INSTANCE = {};
+
 QuickMLP& QuickMLP::Instance()
 {
-    static QuickMLP INSTANCE;
-    return INSTANCE;
+    if (!INSTANCE)
+    {
+        INSTANCE = std::unique_ptr<QuickMLP>(new QuickMLP);
+    }
+    return *INSTANCE;
+}
+
+void QuickMLP::DeleteInstance()
+{
+    INSTANCE = {};
 }
 
 bool QuickMLP::isCudaAvailable() const


### PR DESCRIPTION
This PR adds a new function for early deletion of the QuickMLP instance. This is necessary for programs managing their own CUDA context using the driver API, which will most likely no longer be valid at program termination when the global instance is deleted. Also, another CUDA error code is added that should not lead to program termination at startup.
